### PR TITLE
Remove 'New ...' links from Admin dropdown menu

### DIFF
--- a/app/views/partials/_nav.html.erb
+++ b/app/views/partials/_nav.html.erb
@@ -25,13 +25,6 @@
             <li role="separator" class="divider"></li>
             <li><%= link_to 'All First Names', first_names_path %></li>
             <li><%= link_to 'All Last Names', last_names_path %></li>
-            <li role="separator" class="divider"></li>
-            <li><%= link_to 'New Character', new_character_path %></li>
-            <li><%= link_to 'New Situation', new_situation_path %></li>
-            <li><%= link_to 'New Place', new_place_path %></li>
-            <li role="separator" class="divider"></li>
-            <li><%= link_to 'New First Name', new_first_name_path %></li>
-            <li><%= link_to 'New Last Name', new_last_name_path %></li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
Remove every 'New ...' from the Admin dropdown.

![screen shot 2017-07-01 at 17 21 51](https://user-images.githubusercontent.com/18640195/27763775-234a4448-5e82-11e7-94e8-bf3ab4a6520a.png)

This is because it isn't needed - e.g. there is a New Character button within the Character #index:

![screen shot 2017-07-01 at 17 25 53](https://user-images.githubusercontent.com/18640195/27763787-418435c2-5e82-11e7-94e9-9708e286c046.png)
