### PR TITLE
Add 'Did you know?' information to generators and move footer text into locales

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,3 +48,8 @@
   padding: 0 300px 0 300px;
   text-align: center;
 }
+
+.did_you_know {
+  font-size: 11px;
+  text-align: center;
+}

--- a/app/views/character_name/index.html.erb
+++ b/app/views/character_name/index.html.erb
@@ -9,3 +9,5 @@
 <blockquote class="quote">
   <p class="text-muted"><%= t('character_name.quote') %></p>
 </blockquote>
+
+<p class="did_you_know"><%= t('character_name.example') %></p>

--- a/app/views/partials/_footer.html.erb
+++ b/app/views/partials/_footer.html.erb
@@ -1,3 +1,3 @@
 <div id="footer">
-  <h6 align="center">2017 &copy; Alexandra Wolfe <%= link_to 'https://github.com/rubyandcoffee/story_generator' do %><%= image_tag 'github.png' %><% end %></h6>
+  <h6 align="center"><%= raw t('footer.copyright') %><%= link_to 'https://github.com/rubyandcoffee/story_generator' do %><%= image_tag 'github.png' %><% end %></h6>
 </div>

--- a/app/views/story_plot/index.html.erb
+++ b/app/views/story_plot/index.html.erb
@@ -9,3 +9,5 @@
 <blockquote class="quote">
   <p class="text-muted"><%= t('story_plot.quote') %></p>
 </blockquote>
+
+<p class="did_you_know"><%= t('story_plot.example') %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,8 @@ en:
   story_plot:
     title: Story Plot Generator
     quote: "Plot-driven stories place a larger emphasis on the actual plot itself. Factors such as plot twists, action and external conflict are what make up the focus of this style of writing. In most cases, the goals of the story are more external in that they are focused on the development of a situation."
+    example: Did you know? Romeo and Juliet is a plot-driven story.
   character_name:
     title: Character Name Generator
     quote: "Character-driven writing focuses on the inner conflict of the characters that you’ve created. If you choose to use this writing style, your reader will spend time thinking about the characters and their attitudes, personal evolutions and decisions, and how those, in turn, change the shape of the plot and the story as a whole."
+    example: Did you know? Pride and Prejudice is a character-driven story.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,3 +13,5 @@ en:
     title: Character Name Generator
     quote: "Character-driven writing focuses on the inner conflict of the characters that you’ve created. If you choose to use this writing style, your reader will spend time thinking about the characters and their attitudes, personal evolutions and decisions, and how those, in turn, change the shape of the plot and the story as a whole."
     example: Did you know? Pride and Prejudice is a character-driven story.
+  footer:
+    copyright: "2017 &copy; Alexandra Wolfe"


### PR DESCRIPTION
This PR does two things, plus a cute bonus:

1. Adds a 'Did you know?' information section to the generator pages:

![screen shot 2017-07-02 at 00 44 04](https://user-images.githubusercontent.com/18640195/27766170-74227eca-5ebf-11e7-88d0-05f7d834b3ae.png)

2. It also moves the footer text into a translation file.

---

**Bonus:** Switch example locales on generators to the correct way round. In the locale files, the `example` for `story_plot` would be under `character_name.example` and vice versa. This has now been fixed.